### PR TITLE
add delete() to objectset

### DIFF
--- a/lib/DBIx/Class/Objects/Base.pm
+++ b/lib/DBIx/Class/Objects/Base.pm
@@ -34,6 +34,11 @@ sub update {
     }
 }
 
+sub delete {
+    my $self = shift;
+    $self->result_source->delete;
+}
+
 1;
 
 __END__

--- a/t/objectset.t
+++ b/t/objectset.t
@@ -41,4 +41,16 @@ foreach my $item (@items) {
       '... and the search parameters should be respected';
 }
 
+my $all = $objects->objectset('Item')->all;
+cmp_ok $all, '==', 3, 'got 3 records';
+
+$objects->objectset('Item')->first->delete;
+
+$all = $objects->objectset('Item')->all;
+cmp_ok $all, '==', 2, '... down to got 2';
+
+$objects->objectset('Item')->delete_all;
+$all = $objects->objectset('Item')->all;
+ok !defined $all, '... down to zero';
+
 done_testing;


### PR DESCRIPTION
You could get at delete() by going through the result_source, but delete_all() was broken, and would bomb in DBIx::Class.
